### PR TITLE
feat(utf8): convert content to UTF-8 instead of ISO_8859_1

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,11 @@ This is a VB.NET version of an old VB6 ActiveX library.
 The original VB6 code and documentation can be found here: http://vb-zoom.sourceforge.net/
 
 ## Create nuget package
-```
+``` powershell
 cd \VBZOOMD\VBZOOMD
 .\nuget.exe pack .\VBZOOMD.vbproj -properties Configuration=Release
+```
+## Publish nuget package
+``` powershell
+.\nuget.exe push .\VBZOOMD.x.x.x.nupkg -Source https://nuget.pkg.github.com/Notalib/index.json -ApiKey [GITHUB-PAT-TOKEN]
 ```

--- a/VBZOOMD/VBZOOMD/VBZOOMD.nuspec
+++ b/VBZOOMD/VBZOOMD/VBZOOMD.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>VBZOOMD</id>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
     <title>VBZOOMD</title>
     <authors>University of Illinois at Urbana-Champaign</authors>
     <owners>University of Illinois at Urbana-Champaign</owners>
     <description>VB.NET Wrapper for YAZ ZOOM Z39.50 Libraries</description>
     <copyright>Copyright © 2015 The Board of Trustees of the University of Illinois. All rights reserved.</copyright>
+    <repository type="git" url="https://github.com/Notalib/BibKAT.git" />
     <dependencies>
       <group targetFramework=".NETStandard2.0" />
     </dependencies>

--- a/VBZOOMD/VBZOOMD/ZoomUtil.vb
+++ b/VBZOOMD/VBZOOMD/ZoomUtil.vb
@@ -48,7 +48,7 @@
         'trim the null string terminator
         ReDim Preserve bytes(bytes.Count - 2)
 
-        Return Text.Encoding.GetEncoding(ISO_8859_1).GetString(bytes)
+        Return Text.Encoding.GetEncoding(UTF_8).GetString(bytes)
     End Function
 
     ''' <summary>


### PR DESCRIPTION
NOTA-9442

* convert record to `UTF-8` instead of `ISO_8859_1` (record from DBC will be sent in `UTF-8` encoding)
* upgrade version number to `1.1.1`
* Update `README.md` file